### PR TITLE
Change hashbang to bash because "export -f" needs it.

### DIFF
--- a/vagrant-peco
+++ b/vagrant-peco
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 vagrant_peco() {
   if [ $1 = "ssh" ]; then


### PR DESCRIPTION
On systems such as Debian & Ubuntu /bin/sh points to dash instead of bash and so doesn't support "export -f". Hashbang pointing to bash would ensure bash is actually used.